### PR TITLE
Change the search semantics to match LDAP '='

### DIFF
--- a/src/main/java/net/wimpi/crowd/ldap/CrowdPartition.java
+++ b/src/main/java/net/wimpi/crowd/ldap/CrowdPartition.java
@@ -518,7 +518,7 @@ public class CrowdPartition implements Partition {
               userName = NullRestrictionImpl.INSTANCE;
               
           } else {
-              userName = new TermRestriction<String>(UserTermKeys.USERNAME, MatchMode.CONTAINS, uid);
+              userName = new TermRestriction<String>(UserTermKeys.USERNAME, MatchMode.EXACTLY_MATCHES, uid);
           }
           List<String> list = m_CrowdClient.searchUserNames(userName, 0, Integer.MAX_VALUE);
           for (String gn : list) {


### PR DESCRIPTION
The LDAP adapter currently uses '~=' semantics
for a '=' search, which fails for a number
of users.
